### PR TITLE
D8CORE-7106 | @jdwjdwjdw | Remove wordmark from brand bar

### DIFF
--- a/templates/components/brand-bar/brand-bar.html.twig
+++ b/templates/components/brand-bar/brand-bar.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Brand Bar Component.
+ *
+ * Stanford brand bar with the wordmark logo with four variants:
+ *   - Default: White wordmark over cardinal red background
+ *   - Bright: White wordmark over bright red background
+ *   - Dark: White wordmark over dark grey background
+ *   - White: Cardinal red wordmark over white background
+ *
+ * Available variables:
+ * - attributes: For additional HTML attributes not already provided.
+ * - modifier_class: Additional css classes to change look and behaviour.
+ */
+#}
+
+<div class="su-brand-bar {{ modifier_class }}"></div>

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * Page.html.twig from stanford_basic.
+ */
+#}
+{%- extends "@stanford_basic/page.html.twig" -%}
+
+{# Change the brand bar. #}
+{%- if template_brand_bar is empty -%}
+  {%- set template_brand_bar = "@faculty_subtheme/components/brand-bar/brand-bar.html.twig" -%}
+{%- endif -%}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [D8CORE-7106](https://stanfordits.atlassian.net/browse/D8CORE-7106): DEV | Brand bar option with no wordmark

# Review By (Date)
- When convenient

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch.
2. Review the brand bar and confirm the `Stanford University` wordmark has been removed, but the bar still appears and can be set to different colors as it typically does.
3. Review code 🌴

# Associated Issues and/or People
- [D8CORE-7106](https://stanfordits.atlassian.net/browse/D8CORE-7106): DEV | Brand bar option with no wordmark

[D8CORE-7106]: https://stanfordits.atlassian.net/browse/D8CORE-7106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-7106]: https://stanfordits.atlassian.net/browse/D8CORE-7106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ